### PR TITLE
Traefik deployment

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -1,7 +1,6 @@
 # Environment variable overrides for local development
 DEBUG=true
 DATABASE_URL=sqlite:///data.db
-WEBSITE_URL="http://localhost"
 API_URL="http://localhost:8000"
 TRAEFIK_HOST="wwfrontend.docker.localhost"
 

--- a/.env.prod
+++ b/.env.prod
@@ -1,7 +1,6 @@
 # Environment variable overrides for local development
 DEBUG=true
 DATABASE_URL=sqlite:///data.db
-WEBSITE_URL="https://example.com"
 API_URL="http://wwbackend:8000"
 TRAEFIK_HOST="example.com"
 

--- a/.env.trafik
+++ b/.env.trafik
@@ -8,8 +8,8 @@ DATABASE_URL=sqlite:///data.db
 WEBSITE_URL="https://wurwolves.duckdns.org"
 API_URL="http://wwbackend:8000"
 
-# Domain of service
-DOMAIN=wurwolves.duckdns.org
+# Host of service for traefik
+TRAFIK_HOST=wurwolves.duckdns.org
 
 # Duckdns domain renewal settings
 DUCKDNS_DOMAINS=wurwolves

--- a/.env.trafik
+++ b/.env.trafik
@@ -1,0 +1,35 @@
+# Compose files to include
+COMPOSE_FILE=compose.yml:compose.duckdns.yml:compose.traefik.yml
+
+# Environment variable overrides for local development
+DEBUG=false
+DATABASE_URL=sqlite:///data.db
+
+WEBSITE_URL="https://wurwolves.duckdns.org"
+API_URL="http://wwbackend:8000"
+
+# Domain of service
+DOMAIN=wurwolves.duckdns.org
+
+# Duckdns domain renewal settings
+DUCKDNS_DOMAINS=wurwolves
+DUCKDNS_TOKEN=<insert token here>
+
+GUNICORN_WORKERS=1
+SECRET_KEY=not-so-secret
+
+# In production, set to a higher number, like 31556926
+SEND_FILE_MAX_AGE_DEFAULT=31556926
+
+# Log level for python logging module. Note capitals!
+LOG_LEVEL=DEBUG
+
+# If desired, adjust the log level of individual loggers like so:
+# LOG_OVERRIDES=somelogger:DEBUG,anotherlogger:WARNING
+
+# Set to anything non-blank to output database debugging messages:
+# DEBUG_DATABASE=true
+
+# Set to anything non-blank to use the production database for testing
+# WARNING! This will wipe your database! Use with care.
+# IGNORE_TESTING_DB=true

--- a/.env.trafik
+++ b/.env.trafik
@@ -5,7 +5,6 @@ COMPOSE_FILE=compose.yml:compose.duckdns.yml:compose.traefik.yml
 DEBUG=false
 DATABASE_URL=sqlite:///data.db
 
-WEBSITE_URL="https://wurwolves.duckdns.org"
 API_URL="http://wwbackend:8000"
 
 # Host of service for traefik

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,7 @@ repos:
       - id: end-of-file-fixer
       - id: mixed-line-ending
       - id: check-yaml
+        args: [--unsafe]
 
   # Sort python imports
   # Use fork until https://github.com/psf/black/issues/4175 is fixed (possibly never)

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,9 +1,5 @@
-# {
-# 	http_port 80
-# 	https_port 443
-# }
 
-{$WEBSITE_URL:https://localhost} {
+http://, https://localhost {
 	# encode gzip
 
 	handle /api/* {

--- a/compose.duckdns.yml
+++ b/compose.duckdns.yml
@@ -1,0 +1,16 @@
+
+services:
+  duckdns:
+    image: lscr.io/linuxserver/duckdns:latest
+    container_name: duckdns
+    network_mode: host #optional
+    environment:
+      - PUID=1000 #optional
+      - PGID=1000 #optional
+      - TZ=Etc/UTC #optional
+      - SUBDOMAINS=${DUCKDNS_DOMAINS}
+      - TOKEN=${DUCKDNS_TOKEN}
+      - UPDATE_IP=ipv4 #optional
+      - LOG_FILE=false #optional
+    restart: unless-stopped
+

--- a/compose.traefik.yml
+++ b/compose.traefik.yml
@@ -9,8 +9,7 @@ services:
     labels:
       traefik.enable: true
       traefik.docker.network: traefik
-      traefik.http.routers.mattermost.entrypoints: https
-      traefik.http.routers.mattermost.rule: 'Host(`${TRAFIK_HOST}`)'
+      traefik.http.routers.wwfrontend.rule: 'Host(`${TRAFIK_HOST}`)'
     networks:
       - default
       - traefik

--- a/compose.traefik.yml
+++ b/compose.traefik.yml
@@ -12,6 +12,13 @@ services:
       traefik.http.routers.wwfrontend.rule: 'Host(`${TRAFIK_HOST}`)'
       traefik.http.routers.wwfrontend.entrypoints: https
       traefik.http.routers.wwfrontend.tls.certresolver: letsencrypt-cloudflare
+
+      # HTTP redirection
+      traefik.http.routers.wwfrontend-http.entrypoints: http
+      traefik.http.routers.wwfrontend-http.rule: 'Host(`${TRAFIK_HOST}`)'
+      traefik.http.middlewares.https-redirect.redirectscheme.scheme: https
+      traefik.http.routers.wwfrontend-http.middlewares: https-redirect
+
     networks:
       - default
       - traefik

--- a/compose.traefik.yml
+++ b/compose.traefik.yml
@@ -10,7 +10,7 @@ services:
       traefik.enable: true
       traefik.docker.network: traefik
       traefik.http.routers.wwfrontend.rule: 'Host(`${TRAFIK_HOST}`)'
-      traefik.http.routers.traefik-https.tls.certresolver: letsencrypt-cloudflare
+      traefik.http.routers.wwfrontend.tls.certresolver: letsencrypt-cloudflare
     networks:
       - default
       - traefik

--- a/compose.traefik.yml
+++ b/compose.traefik.yml
@@ -10,6 +10,7 @@ services:
       traefik.enable: true
       traefik.docker.network: traefik
       traefik.http.routers.wwfrontend.rule: 'Host(`${TRAFIK_HOST}`)'
+      traefik.http.routers.wwfrontend.entrypoints: https
       traefik.http.routers.wwfrontend.tls.certresolver: letsencrypt-cloudflare
     networks:
       - default

--- a/compose.traefik.yml
+++ b/compose.traefik.yml
@@ -10,7 +10,7 @@ services:
       traefik.enable: true
       traefik.docker.network: traefik
       traefik.http.routers.mattermost.entrypoints: https
-      traefik.http.routers.mattermost.rule: 'Host(`${DOMAIN}`)'
+      traefik.http.routers.mattermost.rule: 'Host(`${TRAFIK_HOST}`)'
     networks:
       - default
       - traefik

--- a/compose.traefik.yml
+++ b/compose.traefik.yml
@@ -10,6 +10,7 @@ services:
       traefik.enable: true
       traefik.docker.network: traefik
       traefik.http.routers.wwfrontend.rule: 'Host(`${TRAFIK_HOST}`)'
+      traefik.http.routers.traefik-https.tls.certresolver: letsencrypt-cloudflare
     networks:
       - default
       - traefik

--- a/compose.traefik.yml
+++ b/compose.traefik.yml
@@ -1,0 +1,20 @@
+# Expose this service via a traefik instance
+# 1. Traefik must be already running 
+# 2. The network "traefik" must exist and traefik must be connected to it
+
+services:
+  wwfrontend:
+    ports: !reset []
+    # Copied from https://gist.github.com/lfache/a02c01dde1e55345f4583cfce724cf1f:
+    labels:
+      traefik.enable: true
+      traefik.docker.network: traefik
+      traefik.http.routers.mattermost.entrypoints: https
+      traefik.http.routers.mattermost.rule: 'Host(`${DOMAIN}`)'
+    networks:
+      - default
+      - traefik
+
+networks:
+  traefik:
+      external: true

--- a/compose.yml
+++ b/compose.yml
@@ -3,21 +3,17 @@ services:
     image: wurwolves-frontend
     environment:
     - API_URL
-    - WEBSITE_URL
-    - TRAEFIK_HOST
+    # - WEBSITE_URL
     - XDG_CONFIG_HOME=/config
     - XDG_DATA_HOME=/data
-    ports:
+    ports: 
     - 80:80
     - 443:443
     volumes:
     - caddy_data:/data
     - caddy_config:/config
-    restart: always
-    labels:
-      - "traefik.http.routers.wwfrontend.rule=Host(`${TRAEFIK_HOST}`)"
-
-
+    restart: always    
+    
   wwbackend:
     image: wurwolves-backend
     environment:
@@ -33,14 +29,14 @@ services:
     - ./logs:/data/logs
     restart: always
 
-  cloudflare-ddns:
-    image: oznu/cloudflare-ddns:latest
-    restart: always
-    environment:
-    - API_KEY=${CLOUDFLARE_KEY}
-    - ZONE=${CLOUDFLARE_DOMAIN}
-    - SUBDOMAIN=${CLOUDFLARE_SUBDOMAIN}
-    - PROXIED=false
+  # cloudflare-ddns:
+  #   image: oznu/cloudflare-ddns:latest
+  #   restart: always
+  #   environment:
+  #   - API_KEY=${CLOUDFLARE_KEY}
+  #   - ZONE=${CLOUDFLARE_DOMAIN}
+  #   - SUBDOMAIN=${CLOUDFLARE_SUBDOMAIN}
+  #   - PROXIED=false
 
 volumes:
   caddy_data:

--- a/compose.yml
+++ b/compose.yml
@@ -3,7 +3,6 @@ services:
     image: wurwolves-frontend
     environment:
     - API_URL
-    # - WEBSITE_URL
     - XDG_CONFIG_HOME=/config
     - XDG_DATA_HOME=/data
     ports: 
@@ -20,7 +19,6 @@ services:
     - DATABASE_URL
     - MAKE_DEBUG_ENTRIES
     - SECRET_KEY
-    - WEBSITE_URL
     - LOG_LEVEL
     - LOG_OVERRIDES
     - GUNICORN_WORKERS

--- a/readme.md
+++ b/readme.md
@@ -20,6 +20,14 @@ or:
 2. `nix run` to build docker images and store them in the local registry
 3. `docker compose up`
 
+Traefik
+-------
+
+The default instructions above will launch a local service for testing. To
+deploy properly, use the ".env.traefik" template to wire these containers into
+traefik for SSL certificates. You will need to also have a traefik instance
+running and connected to the docker network called "traefik". HTTPS negotiation
+is out of scope for this repository - set it up in traefik. 
 
 Local development
 -----------------

--- a/readme.md
+++ b/readme.md
@@ -23,11 +23,13 @@ or:
 Traefik
 -------
 
-The default instructions above will launch a local service for testing. To
-deploy properly, use the ".env.traefik" template to wire these containers into
-traefik for SSL certificates. You will need to also have a traefik instance
-running and connected to the docker network called "traefik". HTTPS negotiation
-is out of scope for this repository - set it up in traefik. 
+The default instructions above will launch a local service using caddy with
+self-signed certificates. You could use caddy directly by altering the Caddyfile to let caddy negotiate HTTPS on your behalf. However, I've set this up to use traefik instead so that this app can be hosted next to others. 
+
+To deploy, use the ".env.traefik" template to wire these containers into traefik
+for SSL certificates. You will need to also have a traefik instance running and
+connected to the docker network called "traefik". HTTPS negotiation is out of
+scope for this repository - set it up in traefik. 
 
 Local development
 -----------------


### PR DESCRIPTION
Add traefik support - still use caddy, but only for reverse proxy now, not https